### PR TITLE
Use love.filesystem.load instead of dofile for lua files

### DIFF
--- a/cargo.lua
+++ b/cargo.lua
@@ -14,8 +14,12 @@ local function makeFont(path)
   end
 end
 
+local function loadFile(path)
+  return lf.load(path)()
+end
+
 cargo.loaders = {
-  lua = dofile,
+  lua = lf and loadFile,
   png = lg and lg.newImage,
   jpg = lg and lg.newImage,
   dds = lg and lg.newImage,


### PR DESCRIPTION
dofile does not work with .love files, and does not match up to love.filesystem paths. By using love.filesystem.load, cargo follows the behaviour of require, and the rest of love.
