### PR TITLE
Explicitly error when no matching file was found

### DIFF
--- a/cargo.lua
+++ b/cargo.lua
@@ -60,7 +60,7 @@ function cargo.init(config)
       end
     end
 
-    return rawget(t, k)
+    return error("[cargo] No matching file for path " .. path)
   end
 
   init = function(path)


### PR DESCRIPTION
Error messages are now (hopefully) more obvious, rather than just nil indexing errors
