### PR TITLE
Support ignoring file types by setting loader to false;

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Here is a list of default loaders used:
 
 The loader for `.ttf` files is special. Instead of directly returning an asset, this loader returns a function that accepts a size for the font and returns a new font with the specified size.
 
+To have cargo ignore files with a certain extension, specify `false` as the loader.
+
 ### Processors
 
 Sometimes, it can be helpful to do some extra processing on assets after they are loaded.

--- a/cargo.lua
+++ b/cargo.lua
@@ -51,7 +51,7 @@ function cargo.init(config)
     else
       for extension, loader in pairs(loaders) do
         local file = path .. '.' .. extension
-        if lf.exists(file) then
+        if loader and lf.exists(file) then
           local asset = loader(file)
           rawset(t, k, asset)
           for pattern, processor in pairs(processors) do


### PR DESCRIPTION
In the event that there are assets with the same name but different extensions (e.g. `image.png` and `image.dds`), it can be helpful to ignore certain file extensions when loading assets with cargo.  This change allows you to specify a loader of `false` to prevent cargo from loading files of a given type.

This isn't a perfect solution, as it does not allow for ignoring assets based on their name or their path.  A table of patterns similar to the `processors` option could be a future improvement.

Fixes #4.
