### PR TITLE
Add support for bitmap font files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Here is a list of default loaders used:
 
 The loader for `.ttf` and `.otf` files is special. Instead of directly returning an asset, this loader returns a function that accepts a size for the font and returns a new font with the specified size.
 
-The loader for `.fnt` files requires the image file path to be set in the file as it won't be passed to [https://love2d.org/wiki/love.graphics.newFont#Function_3](love.graphics.newFont).
+The loader for `.fnt` files requires the image file path to be set in the file as it won't be passed to [love.graphics.newFont](https://love2d.org/wiki/love.graphics.newFont#Function_3).
 
 To have cargo ignore files with a certain extension, specify `false` as the loader.
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ Here is a list of default loaders used:
 | ogg       | `love.audio.newSource`    |
 | wav       | `love.audio.newSource`    |
 | txt       | `love.filesystem.read`    |
+| fnt       | `love.graphics.newFont`   |
 
 The loader for `.ttf` and `.otf` files is special. Instead of directly returning an asset, this loader returns a function that accepts a size for the font and returns a new font with the specified size.
+
+The loader for `.fnt` files requires the image file path to be set in the file as it won't be passed to [https://love2d.org/wiki/love.graphics.newFont#Function_3](love.graphics.newFont).
 
 To have cargo ignore files with a certain extension, specify `false` as the loader.
 

--- a/cargo.lua
+++ b/cargo.lua
@@ -34,7 +34,8 @@ cargo.loaders = {
   wav = la and la.newSource,
   txt = lf and lf.read,
   ttf = lg and makeFont,
-  otf = lg and makeFont
+  otf = lg and makeFont,
+  fnt = lg and lg.newFont
 }
 
 cargo.processors = {}


### PR DESCRIPTION
This adds `love.graphics.newFont` as a loader for `.fnt` files. As the image file path won't be passed it must be set properly in the `.fnt` file. I did try doing something similar to `makeFont`, returning a function that take the image file path, however it seems counter-productive having to set a file path in the code when using a file loader.